### PR TITLE
feat: el alumno puede pertenecer a vartios grupos, puede ver videos de varios grupos

### DIFF
--- a/app/anexo22/page.tsx
+++ b/app/anexo22/page.tsx
@@ -8,29 +8,16 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-import { getAllCaseStudies, getUserWithProfile } from "@/lib/helpers-server";
+import {
+  getAllCaseStudies,
+  getPermittedVideos,
+  getUserWithProfile,
+} from "@/lib/helpers-server";
 import { ArrowRight, FileText, Package, Shield } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import type React from "react";
 import { CourseMaterial } from "@/components/shared/CourseMaterial";
 import { ClassVideos } from "@/components/shared/ClassVideos";
-import prisma from "@/lib/prisma";
-import { Prisma } from "@/lib/generated/prisma";
-
-// 1. Definimos la consulta y la validamos con 'satisfies'
-const videoQueryArgs = {
-  select: {
-    id: true,
-    title: true,
-    description: true,
-    youtubeId: true,
-  },
-  orderBy: { createdAt: "desc" },
-} satisfies Prisma.VideoFindManyArgs;
-
-// 2. Derivamos el tipo exacto del resultado de la consulta usando GetPayload
-type PermittedVideo = Prisma.VideoGetPayload<typeof videoQueryArgs>;
 
 export default async function Anexo22Page() {
   const userWithProfile = await getUserWithProfile();
@@ -39,16 +26,10 @@ export default async function Anexo22Page() {
   }
 
   const caseStudies = getAllCaseStudies();
-
-  let permittedVideos: PermittedVideo[] = [];
-  if (userWithProfile.profile.groupId) {
-    permittedVideos = await prisma.video.findMany({
-      ...videoQueryArgs,
-      where: {
-        groupId: userWithProfile.profile.groupId,
-      },
-    });
-  }
+  const permittedVideos = await getPermittedVideos(
+    userWithProfile.user.id,
+    "anexo22",
+  );
 
   return (
     <div className="bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 min-h-screen">

--- a/app/clasificacion-arancelaria/page.tsx
+++ b/app/clasificacion-arancelaria/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { HomeContent } from "@/components/clasificacion-arancelaria/shared/home-content";
+import { ClassVideos } from "@/components/shared/ClassVideos";
+import { getPermittedVideos, getUserWithProfile } from "@/lib/helpers-server";
 
 export const metadata: Metadata = {
   title: "Clasificación Arancelaria",
@@ -7,10 +9,29 @@ export const metadata: Metadata = {
     "Explora la LIGIE y aprende clasificación arancelaria con casos prácticos de ANMINCADISA",
 };
 
-export default function ClasificacionArancelariaPage() {
+export default async function ClasificacionArancelariaPage() {
+  const userWithProfile = await getUserWithProfile();
+  const permittedVideos = userWithProfile
+    ? await getPermittedVideos(
+        userWithProfile.user.id,
+        "clasificacion-arancelaria",
+      )
+    : [];
+
   return (
     <>
       <HomeContent />
+      <section className="container mx-auto px-4 py-8 sm:py-12 max-w-5xl">
+        <div className="text-center mb-8">
+          <h2
+            className="text-2xl sm:text-3xl font-bold text-foreground"
+            style={{ color: "var(--turquoise)" }}
+          >
+            Videos de la Clase
+          </h2>
+        </div>
+        <ClassVideos videos={permittedVideos} />
+      </section>
       <footer className="border-t border-border mt-12 sm:mt-16 py-6 sm:py-8">
         <div className="container mx-auto px-4 text-center text-xs sm:text-sm text-muted-foreground space-y-2">
           <p className="font-semibold text-foreground">ANMINCADISA</p>

--- a/app/clasificacion-arancelaria/page.tsx
+++ b/app/clasificacion-arancelaria/page.tsx
@@ -21,17 +21,19 @@ export default async function ClasificacionArancelariaPage() {
   return (
     <>
       <HomeContent />
-      <section className="container mx-auto px-4 py-8 sm:py-12 max-w-5xl">
-        <div className="text-center mb-8">
-          <h2
-            className="text-2xl sm:text-3xl font-bold text-foreground"
-            style={{ color: "var(--turquoise)" }}
-          >
-            Videos de la Clase
-          </h2>
-        </div>
-        <ClassVideos videos={permittedVideos} />
-      </section>
+      {userWithProfile && (
+        <section className="container mx-auto px-4 py-8 sm:py-12 max-w-5xl">
+          <div className="text-center mb-8">
+            <h2
+              className="text-2xl sm:text-3xl font-bold text-foreground"
+              style={{ color: "var(--turquoise)" }}
+            >
+              Videos de la Clase
+            </h2>
+          </div>
+          <ClassVideos videos={permittedVideos} />
+        </section>
+      )}
       <footer className="border-t border-border mt-12 sm:mt-16 py-6 sm:py-8">
         <div className="container mx-auto px-4 text-center text-xs sm:text-sm text-muted-foreground space-y-2">
           <p className="font-semibold text-foreground">ANMINCADISA</p>

--- a/components/admin/CreateUserForm.tsx
+++ b/components/admin/CreateUserForm.tsx
@@ -27,11 +27,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { createUser } from "@/lib/actions/adminUsers";
 import { createUserSchema, type CreateUserFormValues } from "@/lib/validation";
 import { COURSES } from "@/lib/constants/courses";
-
-const NO_GROUP_VALUE = "__none__";
+import { GroupsMultiSelect } from "@/components/admin/GroupsMultiSelect";
 
 interface CreateUserFormProps {
-  groups: Array<{ id: string; name: string }>;
+  groups: Array<{ id: string; name: string; courseSlug: string | null }>;
 }
 
 export function CreateUserForm({ groups }: CreateUserFormProps) {
@@ -45,17 +44,16 @@ export function CreateUserForm({ groups }: CreateUserFormProps) {
       name: "",
       password: "",
       role: "user",
-      groupId: undefined,
+      groupIds: [],
       courseSlugs: [],
     },
   });
 
   const onSubmit = (data: CreateUserFormValues) => {
-    const groupId =
-      data.groupId && data.groupId !== NO_GROUP_VALUE
-        ? data.groupId.trim()
-        : undefined;
-    const payload = { ...data, groupId };
+    const payload = {
+      ...data,
+      groupIds: (data.groupIds ?? []).filter((id) => id?.trim()),
+    };
     startTransition(async () => {
       const result = await createUser(payload);
       if (result.ok) {
@@ -207,32 +205,20 @@ export function CreateUserForm({ groups }: CreateUserFormProps) {
 
         <FormField
           control={form.control}
-          name="groupId"
+          name="groupIds"
           render={({ field }) => (
             <FormItem>
-              <FormLabel htmlFor="groupId">Grupo (opcional)</FormLabel>
+              <FormLabel>Grupos (opcional)</FormLabel>
               {groups.length > 0 ? (
-                <Select
-                  onValueChange={(v) =>
-                    field.onChange(v === NO_GROUP_VALUE ? undefined : v)
-                  }
-                  value={field.value ?? NO_GROUP_VALUE}
-                  disabled={isPending}
-                >
-                  <FormControl>
-                    <SelectTrigger id="groupId">
-                      <SelectValue placeholder="Sin grupo…" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value={NO_GROUP_VALUE}>Sin grupo</SelectItem>
-                    {groups.map((g) => (
-                      <SelectItem key={g.id} value={g.id}>
-                        {g.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <GroupsMultiSelect
+                    groups={groups}
+                    value={field.value ?? []}
+                    onChange={field.onChange}
+                    disabled={isPending}
+                    placeholder="Seleccionar grupos…"
+                  />
+                </FormControl>
               ) : (
                 <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
                   No hay grupos.{" "}

--- a/components/admin/GroupsMultiSelect.tsx
+++ b/components/admin/GroupsMultiSelect.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import { ChevronDown } from "lucide-react";
+import { COURSES } from "@/lib/constants/courses";
+
+interface Group {
+  id: string;
+  name: string;
+  courseSlug: string | null;
+}
+
+interface GroupsMultiSelectProps {
+  groups: Group[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  "aria-label"?: string;
+}
+
+function getGroupLabel(group: Group): string {
+  const courseName = group.courseSlug
+    ? (COURSES.find((c) => c.slug === group.courseSlug)?.name ??
+      group.courseSlug)
+    : null;
+  return courseName ? `${group.name} (${courseName})` : group.name;
+}
+
+function getBadgeVariant(courseSlug: string | null): "default" | "secondary" {
+  return courseSlug === "anexo22" ? "default" : "secondary";
+}
+
+export function GroupsMultiSelect({
+  groups,
+  value,
+  onChange,
+  disabled = false,
+  placeholder = "Seleccionar grupos…",
+  "aria-label": ariaLabel,
+}: GroupsMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggleGroup = (groupId: string) => {
+    if (value.includes(groupId)) {
+      onChange(value.filter((id) => id !== groupId));
+    } else {
+      onChange([...value, groupId]);
+    }
+  };
+
+  const selectedGroups = groups.filter((g) => value.includes(g.id));
+
+  return (
+    <Popover open={open} onOpenChange={(o) => !disabled && setOpen(o)}>
+      <PopoverTrigger asChild>
+        <div
+          role="combobox"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          aria-disabled={disabled}
+          tabIndex={disabled ? -1 : 0}
+          className={`flex flex-nowrap gap-1.5 items-center min-w-0 max-w-full rounded-md p-1.5 transition-colors ${
+            disabled
+              ? "opacity-50 cursor-not-allowed"
+              : "cursor-pointer hover:bg-muted/50"
+          }`}
+        >
+          {selectedGroups.length > 0 ? (
+            <>
+              <span className="flex flex-wrap gap-1.5 flex-1 min-w-0">
+                {selectedGroups.map((g) => (
+                  <Badge
+                    key={g.id}
+                    variant={getBadgeVariant(g.courseSlug)}
+                    className="text-xs font-normal"
+                  >
+                    {g.name}
+                  </Badge>
+                ))}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+            </>
+          ) : (
+            <>
+              <span className="text-muted-foreground text-sm flex-1">
+                {placeholder}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+            </>
+          )}
+        </div>
+      </PopoverTrigger>
+      <PopoverContent className="w-[280px] p-0" align="start">
+        <div className="max-h-[300px] overflow-y-auto p-2">
+          {groups.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No hay grupos. Crea uno en la sección Grupos.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {groups.map((group) => (
+                <label
+                  key={group.id}
+                  className="flex items-center gap-2 text-sm cursor-pointer hover:bg-muted/50 rounded-md p-2"
+                >
+                  <Checkbox
+                    checked={value.includes(group.id)}
+                    onCheckedChange={() => toggleGroup(group.id)}
+                  />
+                  <span>{getGroupLabel(group)}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/admin/GroupsMultiSelect.tsx
+++ b/components/admin/GroupsMultiSelect.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Popover,
@@ -47,6 +47,10 @@ export function GroupsMultiSelect({
   "aria-label": ariaLabel,
 }: GroupsMultiSelectProps) {
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
 
   const toggleGroup = (groupId: string) => {
     if (value.includes(groupId)) {
@@ -109,11 +113,16 @@ export function GroupsMultiSelect({
               {groups.map((group) => (
                 <label
                   key={group.id}
-                  className="flex items-center gap-2 text-sm cursor-pointer hover:bg-muted/50 rounded-md p-2"
+                  className={`flex items-center gap-2 text-sm rounded-md p-2 ${
+                    disabled
+                      ? "cursor-not-allowed opacity-50"
+                      : "cursor-pointer hover:bg-muted/50"
+                  }`}
                 >
                   <Checkbox
                     checked={value.includes(group.id)}
-                    onCheckedChange={() => toggleGroup(group.id)}
+                    onCheckedChange={() => !disabled && toggleGroup(group.id)}
+                    disabled={disabled}
                   />
                   <span>{getGroupLabel(group)}</span>
                 </label>

--- a/components/admin/GroupsTable.tsx
+++ b/components/admin/GroupsTable.tsx
@@ -38,6 +38,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
@@ -53,10 +60,18 @@ import {
   type CreateGroupFormValues,
   type UpdateGroupFormValues,
 } from "@/lib/validation";
+import { COURSES } from "@/lib/constants/courses";
+
+const NONE_COURSE = "__none__";
+const COURSE_SLUG_OPTIONS = [
+  { value: NONE_COURSE, label: "Sin asignar" },
+  ...COURSES.map((c) => ({ value: c.slug, label: c.name })),
+];
 
 interface GroupWithCounts {
   id: string;
   name: string;
+  courseSlug: string | null;
   _count: { profiles: number; videos: number };
 }
 
@@ -76,12 +91,12 @@ export function GroupsTable({ groups }: GroupsTableProps) {
 
   const createForm = useForm<CreateGroupFormValues>({
     resolver: zodResolver(createGroupSchema),
-    defaultValues: { name: "" },
+    defaultValues: { name: "", courseSlug: undefined },
   });
 
   const editForm = useForm<UpdateGroupFormValues>({
     resolver: zodResolver(updateGroupSchema),
-    defaultValues: { id: "", name: "" },
+    defaultValues: { id: "", name: "", courseSlug: null },
   });
 
   const handleCreateSubmit = (data: CreateGroupFormValues) => {
@@ -90,7 +105,7 @@ export function GroupsTable({ groups }: GroupsTableProps) {
       if (result.ok) {
         toast.success(result.message);
         setCreateOpen(false);
-        createForm.reset({ name: "" });
+        createForm.reset({ name: "", courseSlug: undefined });
       } else {
         toast.error(result.message);
         if (result.code === "name_taken") {
@@ -102,7 +117,16 @@ export function GroupsTable({ groups }: GroupsTableProps) {
 
   const handleEditOpen = (group: GroupWithCounts) => {
     setEditingGroup(group);
-    editForm.reset({ id: group.id, name: group.name });
+    const courseSlugValue: UpdateGroupFormValues["courseSlug"] =
+      group.courseSlug === "anexo22" ||
+      group.courseSlug === "clasificacion-arancelaria"
+        ? group.courseSlug
+        : NONE_COURSE;
+    editForm.reset({
+      id: group.id,
+      name: group.name,
+      courseSlug: courseSlugValue,
+    });
   };
 
   const handleEditSubmit = (data: UpdateGroupFormValues) => {
@@ -170,6 +194,34 @@ export function GroupsTable({ groups }: GroupsTableProps) {
                 </FormItem>
               )}
             />
+            <FormField
+              control={createForm.control}
+              name="courseSlug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="create-courseSlug">Curso</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value ?? NONE_COURSE}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger id="create-courseSlug">
+                        <SelectValue placeholder="Sin asignar…" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {COURSE_SLUG_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             <DialogFooter>
               <Button
                 type="button"
@@ -200,6 +252,7 @@ export function GroupsTable({ groups }: GroupsTableProps) {
           <TableHeader>
             <TableRow>
               <TableHead className="px-4 text-left">Nombre</TableHead>
+              <TableHead className="px-4 text-left">Curso</TableHead>
               <TableHead className="px-4 text-center tabular-nums">
                 Usuarios
               </TableHead>
@@ -213,7 +266,7 @@ export function GroupsTable({ groups }: GroupsTableProps) {
             {groups.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={5}
                   className="text-center text-muted-foreground py-12"
                 >
                   <div className="flex flex-col items-center gap-4">
@@ -228,6 +281,12 @@ export function GroupsTable({ groups }: GroupsTableProps) {
                 <TableRow key={group.id} className="hover:bg-blue-100/50">
                   <TableCell className="px-4 text-left font-medium">
                     {group.name}
+                  </TableCell>
+                  <TableCell className="px-4 text-left text-muted-foreground">
+                    {group.courseSlug
+                      ? (COURSES.find((c) => c.slug === group.courseSlug)
+                          ?.name ?? group.courseSlug)
+                      : "—"}
                   </TableCell>
                   <TableCell className="px-4 text-center tabular-nums">
                     {group._count.profiles}
@@ -297,6 +356,36 @@ export function GroupsTable({ groups }: GroupsTableProps) {
                           {...field}
                         />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={editForm.control}
+                  name="courseSlug"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel htmlFor="edit-courseSlug">Curso</FormLabel>
+                      <Select
+                        onValueChange={(v) =>
+                          field.onChange(v === NONE_COURSE ? null : v)
+                        }
+                        value={field.value ?? NONE_COURSE}
+                        disabled={isPending}
+                      >
+                        <FormControl>
+                          <SelectTrigger id="edit-courseSlug">
+                            <SelectValue placeholder="Sin asignar…" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {COURSE_SLUG_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/components/admin/UsersTable.tsx
+++ b/components/admin/UsersTable.tsx
@@ -108,6 +108,9 @@ const dateFormatter = new Intl.DateTimeFormat("es-MX", {
 export function UsersTable({ users, groups }: UsersTableProps) {
   const [isPending, startTransition] = useTransition();
   const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+  const [optimisticGroupIds, setOptimisticGroupIds] = useState<
+    Record<string, string[]>
+  >({});
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [deletingUser, setDeletingUser] = useState<User | null>(null);
   const [coursesUser, setCoursesUser] = useState<User | null>(null);
@@ -144,10 +147,16 @@ export function UsersTable({ users, groups }: UsersTableProps) {
   };
 
   const handleGroupsChange = (userId: string, groupIds: string[]) => {
+    setOptimisticGroupIds((prev) => ({ ...prev, [userId]: groupIds }));
     setUpdatingUserId(userId);
     startTransition(async () => {
       const result = await updateUserGroups({ userId, groupIds });
       setUpdatingUserId(null);
+      setOptimisticGroupIds((prev) => {
+        const next = { ...prev };
+        delete next[userId];
+        return next;
+      });
       if (result.ok) {
         toast.success(result.message);
       } else {
@@ -317,11 +326,13 @@ export function UsersTable({ users, groups }: UsersTableProps) {
                       <GroupsMultiSelect
                         groups={groups}
                         value={
+                          optimisticGroupIds[user.id] ??
                           (user.groupIds?.length
                             ? user.groupIds
                             : user.groupId
                               ? [user.groupId]
-                              : []) ?? []
+                              : []) ??
+                          []
                         }
                         onChange={(v) => handleGroupsChange(user.id, v)}
                         disabled={isPending && updatingUserId === user.id}

--- a/components/admin/UsersTable.tsx
+++ b/components/admin/UsersTable.tsx
@@ -55,7 +55,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   updateUserRole,
-  updateUserGroup,
+  updateUserGroups,
   updateUserName,
   updateUserActive,
   deleteUser,
@@ -80,6 +80,7 @@ import {
 } from "lucide-react";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { normalizeForSearch } from "@/lib/search-utils";
+import { GroupsMultiSelect } from "@/components/admin/GroupsMultiSelect";
 
 interface User {
   id: string;
@@ -87,6 +88,7 @@ interface User {
   name: string | null;
   role: string;
   groupId: string | null;
+  groupIds: string[];
   isActive: boolean;
   enrolledCourseSlugs: string[];
   createdAt: Date;
@@ -94,7 +96,7 @@ interface User {
 
 interface UsersTableProps {
   users: User[];
-  groups: Array<{ id: string; name: string }>;
+  groups: Array<{ id: string; name: string; courseSlug: string | null }>;
 }
 
 const dateFormatter = new Intl.DateTimeFormat("es-MX", {
@@ -102,8 +104,6 @@ const dateFormatter = new Intl.DateTimeFormat("es-MX", {
   month: "long",
   day: "numeric",
 });
-
-const NO_GROUP_VALUE = "__none__";
 
 export function UsersTable({ users, groups }: UsersTableProps) {
   const [isPending, startTransition] = useTransition();
@@ -143,11 +143,10 @@ export function UsersTable({ users, groups }: UsersTableProps) {
     });
   };
 
-  const handleGroupChange = (userId: string, groupId: string | null) => {
-    const value = groupId === NO_GROUP_VALUE ? null : groupId;
+  const handleGroupsChange = (userId: string, groupIds: string[]) => {
     setUpdatingUserId(userId);
     startTransition(async () => {
-      const result = await updateUserGroup({ userId, groupId: value });
+      const result = await updateUserGroups({ userId, groupIds });
       setUpdatingUserId(null);
       if (result.ok) {
         toast.success(result.message);
@@ -313,34 +312,16 @@ export function UsersTable({ users, groups }: UsersTableProps) {
                       {user.role}
                     </Badge>
                   </TableCell>
-                  <TableCell className="px-4 text-left">
-                    <Select
-                      value={user.groupId ?? NO_GROUP_VALUE}
-                      onValueChange={(v) =>
-                        handleGroupChange(
-                          user.id,
-                          v === NO_GROUP_VALUE ? null : v,
-                        )
-                      }
-                      disabled={isPending && updatingUserId === user.id}
-                    >
-                      <SelectTrigger
-                        className="w-[140px]"
-                        aria-label={`Grupo de ${user.email ?? "usuario"}`}
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value={NO_GROUP_VALUE}>
-                          Sin grupo
-                        </SelectItem>
-                        {groups.map((g) => (
-                          <SelectItem key={g.id} value={g.id}>
-                            {g.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                  <TableCell className="px-4 text-left overflow-hidden min-w-0 max-w-[260px]">
+                    <div className="min-w-0">
+                      <GroupsMultiSelect
+                        groups={groups}
+                        value={user.groupIds ?? []}
+                        onChange={(v) => handleGroupsChange(user.id, v)}
+                        disabled={isPending && updatingUserId === user.id}
+                        aria-label={`Grupos de ${user.email ?? "usuario"}`}
+                      />
+                    </div>
                   </TableCell>
                   <TableCell className="px-4 text-left">
                     <div className="flex flex-wrap gap-1">

--- a/components/admin/UsersTable.tsx
+++ b/components/admin/UsersTable.tsx
@@ -316,7 +316,13 @@ export function UsersTable({ users, groups }: UsersTableProps) {
                     <div className="min-w-0">
                       <GroupsMultiSelect
                         groups={groups}
-                        value={user.groupIds ?? []}
+                        value={
+                          (user.groupIds?.length
+                            ? user.groupIds
+                            : user.groupId
+                              ? [user.groupId]
+                              : []) ?? []
+                        }
                         onChange={(v) => handleGroupsChange(user.id, v)}
                         disabled={isPending && updatingUserId === user.id}
                         aria-label={`Grupos de ${user.email ?? "usuario"}`}

--- a/lib/actions/adminGroups.ts
+++ b/lib/actions/adminGroups.ts
@@ -34,7 +34,7 @@ export async function createGroup(
     }
 
     await prisma.group.create({
-      data: { name },
+      data: { name, courseSlug: input.courseSlug ?? undefined },
     });
 
     revalidatePath("/admin/grupos");
@@ -104,7 +104,11 @@ export async function updateGroup(
 
     await prisma.group.update({
       where: { id: input.id },
-      data: { name },
+      data: {
+        name,
+        courseSlug:
+          input.courseSlug !== undefined ? input.courseSlug : undefined,
+      },
     });
 
     revalidatePath("/admin/grupos");
@@ -148,9 +152,7 @@ export async function deleteGroup(id: string): Promise<DeleteGroupResult> {
 
     const group = await prisma.group.findUnique({
       where: { id },
-      include: {
-        _count: { select: { profiles: true, videos: true } },
-      },
+      include: { _count: { select: { videos: true } } },
     });
 
     if (!group) {
@@ -161,7 +163,10 @@ export async function deleteGroup(id: string): Promise<DeleteGroupResult> {
       };
     }
 
-    if (group._count.profiles > 0) {
+    const profilesCount = await prisma.profile.count({
+      where: { groupIds: { has: id } },
+    });
+    if (profilesCount > 0) {
       return {
         ok: false,
         code: "has_profiles",
@@ -198,14 +203,17 @@ export async function deleteGroup(id: string): Promise<DeleteGroupResult> {
 }
 
 type ListGroupsResult =
-  | { ok: true; data: Array<{ id: string; name: string }> }
+  | {
+      ok: true;
+      data: Array<{ id: string; name: string; courseSlug: string | null }>;
+    }
   | { ok: false; code: "auth_required" | "unexpected"; message: string };
 
 export async function listGroups(): Promise<ListGroupsResult> {
   try {
     await requireAdmin();
     const groups = await prisma.group.findMany({
-      select: { id: true, name: true },
+      select: { id: true, name: true, courseSlug: true },
       orderBy: { name: "asc" },
     });
     return { ok: true, data: groups };
@@ -224,6 +232,7 @@ type ListGroupsWithCountsResult =
       data: Array<{
         id: string;
         name: string;
+        courseSlug: string | null;
         _count: { profiles: number; videos: number };
       }>;
     }
@@ -236,11 +245,23 @@ export async function listGroupsWithCounts(): Promise<ListGroupsWithCountsResult
       select: {
         id: true,
         name: true,
-        _count: { select: { profiles: true, videos: true } },
+        courseSlug: true,
+        _count: { select: { videos: true } },
       },
       orderBy: { name: "asc" },
     });
-    return { ok: true, data: groups };
+    const groupsWithCounts = await Promise.all(
+      groups.map(async (g) => ({
+        ...g,
+        _count: {
+          ...g._count,
+          profiles: await prisma.profile.count({
+            where: { groupIds: { has: g.id } },
+          }),
+        },
+      })),
+    );
+    return { ok: true, data: groupsWithCounts };
   } catch {
     return {
       ok: false,

--- a/lib/actions/adminGroups.ts
+++ b/lib/actions/adminGroups.ts
@@ -164,7 +164,9 @@ export async function deleteGroup(id: string): Promise<DeleteGroupResult> {
     }
 
     const profilesCount = await prisma.profile.count({
-      where: { groupIds: { has: id } },
+      where: {
+        OR: [{ groupIds: { has: id } }, { groupId: id }],
+      },
     });
     if (profilesCount > 0) {
       return {
@@ -256,7 +258,9 @@ export async function listGroupsWithCounts(): Promise<ListGroupsWithCountsResult
         _count: {
           ...g._count,
           profiles: await prisma.profile.count({
-            where: { groupIds: { has: g.id } },
+            where: {
+              OR: [{ groupIds: { has: g.id } }, { groupId: g.id }],
+            },
           }),
         },
       })),

--- a/lib/actions/adminGroups.ts
+++ b/lib/actions/adminGroups.ts
@@ -106,8 +106,7 @@ export async function updateGroup(
       where: { id: input.id },
       data: {
         name,
-        courseSlug:
-          input.courseSlug !== undefined ? input.courseSlug : undefined,
+        courseSlug: input.courseSlug,
       },
     });
 

--- a/lib/actions/adminUsers.ts
+++ b/lib/actions/adminUsers.ts
@@ -129,7 +129,7 @@ export async function updateUserGroups(
 
     await prisma.profile.update({
       where: { id: input.userId },
-      data: { groupIds },
+      data: { groupIds, groupId: null },
     });
 
     revalidatePath("/admin/usuarios");

--- a/lib/actions/adminUsers.ts
+++ b/lib/actions/adminUsers.ts
@@ -9,6 +9,7 @@ import {
   createUserSchema,
   updateUserNameSchema,
   updateUserCoursesSchema,
+  updateUserGroupsSchema,
 } from "@/lib/validation";
 import { listGroups } from "@/lib/actions/adminGroups";
 
@@ -17,11 +18,6 @@ export { listGroups };
 const updateUserRoleSchema = z.object({
   userId: z.string(),
   role: z.enum(["user", "admin"]),
-});
-
-const updateUserGroupSchema = z.object({
-  userId: z.string(),
-  groupId: z.string().nullable(),
 });
 
 const updateUserActiveSchema = z.object({
@@ -95,7 +91,7 @@ export async function updateUserRole(
   }
 }
 
-type UpdateUserGroupResult =
+type UpdateUserGroupsResult =
   | { ok: true; message: string }
   | {
       ok: false;
@@ -103,9 +99,9 @@ type UpdateUserGroupResult =
       message: string;
     };
 
-export async function updateUserGroup(
+export async function updateUserGroups(
   rawInput: unknown,
-): Promise<UpdateUserGroupResult> {
+): Promise<UpdateUserGroupsResult> {
   try {
     const result = await requireAdmin();
     if (!result) {
@@ -116,8 +112,8 @@ export async function updateUserGroup(
       };
     }
 
-    const input = updateUserGroupSchema.parse(rawInput);
-    const groupId = input.groupId?.trim() || null;
+    const input = updateUserGroupsSchema.parse(rawInput);
+    const groupIds = (input.groupIds ?? []).filter((id) => id?.trim());
 
     const user = await prisma.profile.findUnique({
       where: { id: input.userId },
@@ -133,13 +129,15 @@ export async function updateUserGroup(
 
     await prisma.profile.update({
       where: { id: input.userId },
-      data: { groupId },
+      data: { groupIds },
     });
 
     revalidatePath("/admin/usuarios");
+    revalidatePath("/anexo22");
+    revalidatePath("/clasificacion-arancelaria");
     return {
       ok: true,
-      message: "Grupo actualizado",
+      message: "Grupos actualizados",
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -149,11 +147,11 @@ export async function updateUserGroup(
         message: "Datos inválidos",
       };
     }
-    console.error("[updateUserGroup] Error:", error);
+    console.error("[updateUserGroups] Error:", error);
     return {
       ok: false,
       code: "unexpected",
-      message: "Error al actualizar el grupo",
+      message: "Error al actualizar los grupos",
     };
   }
 }
@@ -438,6 +436,7 @@ type ListUsersResult =
         name: string | null;
         role: string;
         groupId: string | null;
+        groupIds: string[];
         isActive: boolean;
         enrolledCourseSlugs: string[];
         createdAt: Date;
@@ -457,6 +456,7 @@ export async function listUsers(): Promise<ListUsersResult> {
         name: true,
         role: true,
         groupId: true,
+        groupIds: true,
         isActive: true,
         enrolledCourseSlugs: true,
         createdAt: true,
@@ -502,7 +502,7 @@ export async function createUser(rawInput: unknown): Promise<CreateUserResult> {
     const input = createUserSchema.parse(rawInput);
     const email = input.email.trim().toLowerCase();
     const name = input.name?.trim() || null;
-    const groupId = input.groupId?.trim() || null;
+    const groupIds = (input.groupIds ?? []).filter((id) => id?.trim());
     const enrolledCourseSlugs = input.courseSlugs ?? [];
 
     // Verificar email único en Profile
@@ -563,7 +563,7 @@ export async function createUser(rawInput: unknown): Promise<CreateUserResult> {
           email,
           name,
           role: input.role,
-          groupId: groupId || undefined,
+          groupIds,
           enrolledCourseSlugs,
         },
       });

--- a/lib/actions/adminVideos.ts
+++ b/lib/actions/adminVideos.ts
@@ -47,6 +47,7 @@ export async function createVideo(
 
     revalidatePath("/admin/videos");
     revalidatePath("/anexo22");
+    revalidatePath("/clasificacion-arancelaria");
     return { ok: true, message: "Video creado correctamente" };
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -123,6 +124,7 @@ export async function updateVideo(
 
     revalidatePath("/admin/videos");
     revalidatePath("/anexo22");
+    revalidatePath("/clasificacion-arancelaria");
     return { ok: true, message: "Video actualizado correctamente" };
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -172,6 +174,7 @@ export async function deleteVideo(id: string): Promise<DeleteVideoResult> {
 
     revalidatePath("/admin/videos");
     revalidatePath("/anexo22");
+    revalidatePath("/clasificacion-arancelaria");
     return { ok: true, message: "Video eliminado correctamente" };
   } catch (error) {
     console.error("[deleteVideo] Error:", error);

--- a/lib/helpers-server.ts
+++ b/lib/helpers-server.ts
@@ -6,7 +6,49 @@ import fs from "fs";
 import path from "path";
 import { CaseStudy } from "@/types/pedimento";
 import prisma from "./prisma";
+import { Prisma } from "@/lib/generated/prisma";
 import { COURSES } from "./constants/courses";
+
+const videoQueryArgs = {
+  select: {
+    id: true,
+    title: true,
+    description: true,
+    youtubeId: true,
+  },
+  orderBy: { createdAt: "desc" },
+} satisfies Prisma.VideoFindManyArgs;
+
+export type PermittedVideo = Prisma.VideoGetPayload<typeof videoQueryArgs>;
+
+export const getPermittedVideos = cache(
+  async (profileId: string, courseSlug: string): Promise<PermittedVideo[]> => {
+    const profile = await prisma.profile.findUnique({
+      where: { id: profileId },
+      select: { groupIds: true, groupId: true },
+    });
+    if (!profile) return [];
+    const ids = profile.groupIds?.length
+      ? profile.groupIds
+      : profile.groupId
+        ? [profile.groupId]
+        : [];
+    if (ids.length === 0) return [];
+    const groups = await prisma.group.findMany({
+      where: {
+        id: { in: ids },
+        OR: [{ courseSlug }, { courseSlug: null }],
+      },
+      select: { id: true },
+    });
+    const groupIds = groups.map((g) => g.id);
+    if (groupIds.length === 0) return [];
+    return prisma.video.findMany({
+      ...videoQueryArgs,
+      where: { groupId: { in: groupIds } },
+    });
+  },
+);
 
 export async function getUser() {
   const supabase = await createClient();
@@ -60,6 +102,7 @@ export const getUserWithProfile = cache(async () => {
       email: true,
       name: true,
       groupId: true,
+      groupIds: true,
       role: true,
       isActive: true,
       enrolledCourseSlugs: true,

--- a/lib/helpers-server.ts
+++ b/lib/helpers-server.ts
@@ -34,10 +34,16 @@ export const getPermittedVideos = cache(
         ? [profile.groupId]
         : [];
     if (ids.length === 0) return [];
+    // Legacy groups (courseSlug: null) only appear on anexo22, not on other courses
+    const courseFilter =
+      courseSlug === "anexo22"
+        ? [{ courseSlug: "anexo22" as const }, { courseSlug: null }]
+        : [{ courseSlug }];
+
     const groups = await prisma.group.findMany({
       where: {
         id: { in: ids },
-        OR: [{ courseSlug }, { courseSlug: null }],
+        OR: courseFilter,
       },
       select: { id: true },
     });

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -88,7 +88,7 @@ export const createUserSchema = z.object({
     .trim()
     .min(8, "La contraseña debe tener al menos 8 caracteres"),
   role: z.enum(["user", "admin"]),
-  groupId: z.string().optional(),
+  groupIds: z.array(z.string()).optional(),
   courseSlugs: z
     .array(z.string())
     .min(1, "Selecciona al menos un curso")
@@ -100,6 +100,13 @@ export const createUserSchema = z.object({
       { message: "Curso inválido" },
     ),
 });
+
+// Admin - Actualizar grupos del usuario
+export const updateUserGroupsSchema = z.object({
+  userId: z.string().min(1),
+  groupIds: z.array(z.string()),
+});
+export type UpdateUserGroupsFormValues = z.infer<typeof updateUserGroupsSchema>;
 
 export type CreateUserFormValues = z.infer<typeof createUserSchema>;
 
@@ -129,12 +136,32 @@ export type UpdateUserCoursesFormValues = z.infer<
 >;
 
 // Admin - Grupos
+const courseSlugEnum = z.enum(["anexo22", "clasificacion-arancelaria"]);
+const courseSlugOrNone = z
+  .union([courseSlugEnum, z.literal("__none__")])
+  .optional()
+  .transform((v) =>
+    v && v !== "__none__"
+      ? (v as "anexo22" | "clasificacion-arancelaria")
+      : undefined,
+  );
+const courseSlugOrNoneNullable = z
+  .union([courseSlugEnum, z.literal("__none__")])
+  .nullable()
+  .optional()
+  .transform((v) =>
+    v && v !== "__none__"
+      ? (v as "anexo22" | "clasificacion-arancelaria")
+      : null,
+  );
+
 export const createGroupSchema = z.object({
   name: z
     .string()
     .min(1, "El nombre es requerido")
     .max(100, "Máximo 100 caracteres")
     .trim(),
+  courseSlug: courseSlugOrNone,
 });
 
 export const updateGroupSchema = z.object({
@@ -144,10 +171,11 @@ export const updateGroupSchema = z.object({
     .min(1, "El nombre es requerido")
     .max(100, "Máximo 100 caracteres")
     .trim(),
+  courseSlug: courseSlugOrNoneNullable,
 });
 
-export type CreateGroupFormValues = z.infer<typeof createGroupSchema>;
-export type UpdateGroupFormValues = z.infer<typeof updateGroupSchema>;
+export type CreateGroupFormValues = z.input<typeof createGroupSchema>;
+export type UpdateGroupFormValues = z.input<typeof updateGroupSchema>;
 
 // Admin - Videos
 export const createVideoSchema = z.object({

--- a/prisma/migrations/20260317161303_add_groupids_and_course_slug/migration.sql
+++ b/prisma/migrations/20260317161303_add_groupids_and_course_slug/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "courseSlug" TEXT;
+
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN     "groupIds" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,8 +29,9 @@ model Profile {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  groupId String?
-  group   Group?  @relation(fields: [groupId], references: [id])
+  groupId  String?
+  group    Group?   @relation(fields: [groupId], references: [id])
+  groupIds String[] @default([])
 
   enrolledCourseSlugs String[] @default([])
 
@@ -88,8 +89,9 @@ model Video {
 
 // --- NUEVO MODELO ---
 model Group {
-  id   String @id @default(cuid())
-  name String @unique
+  id         String  @id @default(cuid())
+  name       String  @unique
+  courseSlug String? // "anexo22" | "clasificacion-arancelaria"
 
   // Relaciones
   profiles Profile[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a schema change (`Profile.groupIds`, `Group.courseSlug`) and updates permission logic that controls which course videos a user can see, so bugs could incorrectly grant/deny access or break existing group assignments.
> 
> **Overview**
> Users can now belong to **multiple groups** via a new `Profile.groupIds` field, and groups can be tied to a specific course via `Group.courseSlug` (Prisma schema + migration).
> 
> Video access is refactored into a cached `getPermittedVideos(profileId, courseSlug)` helper and course pages (`/anexo22`, `/clasificacion-arancelaria`) now render class videos based on the user’s permitted groups (including legacy `courseSlug: null` groups for `anexo22`).
> 
> Admin UI/actions are updated to manage these new relationships: users are assigned to multiple groups with a new `GroupsMultiSelect` and `updateUserGroups`, group CRUD now includes course selection, group deletion/counting accounts for both legacy `groupId` and new `groupIds`, and video mutations revalidate the additional course page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4b12cc7e5842992ccb2f74501fc1fa818722f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->