### PR TITLE
fix(enrollment): Simulador aduanero desde grupos en dashboard y reseñas

### DIFF
--- a/lib/actions/adminUsers.ts
+++ b/lib/actions/adminUsers.ts
@@ -12,6 +12,10 @@ import {
   updateUserGroupsSchema,
 } from "@/lib/validation";
 import { listGroups } from "@/lib/actions/adminGroups";
+import {
+  courseSlugsFromGroupIds,
+  mergeEnrolledCourseSlugs,
+} from "@/lib/enrollment/from-groups";
 
 export { listGroups };
 
@@ -117,6 +121,7 @@ export async function updateUserGroups(
 
     const user = await prisma.profile.findUnique({
       where: { id: input.userId },
+      select: { id: true, enrolledCourseSlugs: true },
     });
 
     if (!user) {
@@ -127,14 +132,26 @@ export async function updateUserGroups(
       };
     }
 
+    const fromGroups = await courseSlugsFromGroupIds(groupIds);
+    const enrolledCourseSlugs = mergeEnrolledCourseSlugs(
+      user.enrolledCourseSlugs,
+      fromGroups,
+    );
+
     await prisma.profile.update({
       where: { id: input.userId },
-      data: { groupIds, groupId: null },
+      data: {
+        groupIds,
+        groupId: null,
+        enrolledCourseSlugs,
+      },
     });
 
     revalidatePath("/admin/usuarios");
+    revalidatePath("/dashboard");
     revalidatePath("/anexo22");
     revalidatePath("/clasificacion-arancelaria");
+    revalidatePath("/simulador-aduanero");
     return {
       ok: true,
       message: "Grupos actualizados",
@@ -389,6 +406,10 @@ export async function updateUserCourses(
 
     const user = await prisma.profile.findUnique({
       where: { id: input.userId },
+      select: {
+        groupIds: true,
+        groupId: true,
+      },
     });
 
     if (!user) {
@@ -399,12 +420,21 @@ export async function updateUserCourses(
       };
     }
 
+    const groupIdsResolved =
+      user.groupIds?.length ? user.groupIds : user.groupId ? [user.groupId] : [];
+    const fromGroups = await courseSlugsFromGroupIds(groupIdsResolved);
+    const enrolledCourseSlugs = mergeEnrolledCourseSlugs(
+      input.courseSlugs,
+      fromGroups,
+    );
+
     await prisma.profile.update({
       where: { id: input.userId },
-      data: { enrolledCourseSlugs: input.courseSlugs },
+      data: { enrolledCourseSlugs },
     });
 
     revalidatePath("/admin/usuarios");
+    revalidatePath("/dashboard");
     return {
       ok: true,
       message: "Cursos actualizados",
@@ -503,7 +533,11 @@ export async function createUser(rawInput: unknown): Promise<CreateUserResult> {
     const email = input.email.trim().toLowerCase();
     const name = input.name?.trim() || null;
     const groupIds = (input.groupIds ?? []).filter((id) => id?.trim());
-    const enrolledCourseSlugs = input.courseSlugs ?? [];
+    const fromGroups = await courseSlugsFromGroupIds(groupIds);
+    const enrolledCourseSlugs = mergeEnrolledCourseSlugs(
+      input.courseSlugs ?? [],
+      fromGroups,
+    );
 
     // Verificar email único en Profile
     const existingProfile = await prisma.profile.findUnique({

--- a/lib/actions/testimonialActions.ts
+++ b/lib/actions/testimonialActions.ts
@@ -130,7 +130,9 @@ export async function createTestimonial(
 
     const input = testimonialFormSchema.parse(rawInput);
 
-    const enrolledSet = new Set(result.profile.enrolledCourseSlugs ?? []);
+    const enrolledSet = new Set<string>(
+      result.profile.enrolledCourseSlugs ?? [],
+    );
     if (!enrolledSet.has(input.courseSlug)) {
       return {
         ok: false,

--- a/lib/enrollment/from-groups.ts
+++ b/lib/enrollment/from-groups.ts
@@ -1,0 +1,57 @@
+import prisma from "@/lib/prisma";
+import {
+  COURSE_SLUGS,
+  type CourseSlug,
+} from "@/lib/constants/courses";
+
+const VALID_SLUG_SET = new Set<string>(COURSE_SLUGS);
+
+/**
+ * Curso efectivo derivado del grupo para matrícula y dashboard.
+ * Grupos con `courseSlug: null` (legado) equivalen al curso Anexo 22,
+ * igual que en `getPermittedVideos`.
+ */
+export function enrollmentSlugFromGroup(courseSlug: string | null): CourseSlug | null {
+  if (
+    courseSlug != null &&
+    courseSlug !== "" &&
+    VALID_SLUG_SET.has(courseSlug)
+  ) {
+    return courseSlug as CourseSlug;
+  }
+  if (courseSlug === null) {
+    return "anexo22";
+  }
+  return null;
+}
+
+/** Slugs de curso implícitos en los grupos asignados (sin duplicados). */
+export async function courseSlugsFromGroupIds(
+  groupIds: string[],
+): Promise<CourseSlug[]> {
+  const ids = [...new Set(groupIds.filter((id) => id?.trim()))];
+  if (ids.length === 0) return [];
+  const groups = await prisma.group.findMany({
+    where: { id: { in: ids } },
+    select: { courseSlug: true },
+  });
+  const out = new Set<CourseSlug>();
+  for (const g of groups) {
+    const s = enrollmentSlugFromGroup(g.courseSlug);
+    if (s) out.add(s);
+  }
+  return [...out];
+}
+
+/** Une matrículas ya guardadas con las que corresponden a los grupos. */
+export function mergeEnrolledCourseSlugs(
+  existing: string[] | undefined,
+  fromGroups: CourseSlug[],
+): CourseSlug[] {
+  const merged = new Set<string>();
+  for (const s of existing ?? []) {
+    if (VALID_SLUG_SET.has(s)) merged.add(s);
+  }
+  for (const s of fromGroups) merged.add(s);
+  return COURSE_SLUGS.filter((slug) => merged.has(slug));
+}

--- a/lib/helpers-server.ts
+++ b/lib/helpers-server.ts
@@ -8,6 +8,10 @@ import { CaseStudy } from "@/types/pedimento";
 import prisma from "./prisma";
 import { Prisma } from "@/lib/generated/prisma";
 import { COURSES } from "./constants/courses";
+import {
+  courseSlugsFromGroupIds,
+  mergeEnrolledCourseSlugs,
+} from "./enrollment/from-groups";
 
 const videoQueryArgs = {
   select: {
@@ -94,6 +98,15 @@ export function getAllCaseStudies(): CaseStudy[] {
   }
 }
 
+function resolvedGroupIds(profile: {
+  groupId: string | null;
+  groupIds: string[];
+}): string[] {
+  if (profile.groupIds?.length) return profile.groupIds;
+  if (profile.groupId) return [profile.groupId];
+  return [];
+}
+
 export const getUserWithProfile = cache(async () => {
   const supabase = await createClient();
   const {
@@ -121,7 +134,21 @@ export const getUserWithProfile = cache(async () => {
   const hasAccess = profile.isActive || isAdmin;
   if (!hasAccess) return null;
 
-  return { user, profile };
+  const gid = resolvedGroupIds(profile);
+  const fromGroups =
+    gid.length > 0 ? await courseSlugsFromGroupIds(gid) : [];
+  const enrolledCourseSlugs = mergeEnrolledCourseSlugs(
+    profile.enrolledCourseSlugs,
+    fromGroups,
+  );
+
+  return {
+    user,
+    profile: {
+      ...profile,
+      enrolledCourseSlugs,
+    },
+  };
 });
 
 export async function requireActiveUser() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how effective course enrollment is computed and persisted (including legacy `courseSlug: null` groups), which can affect user access and visibility across multiple pages.
> 
> **Overview**
> Ensures users’ effective course enrollment includes courses implied by their assigned groups (including legacy groups with `courseSlug: null` mapping to `anexo22`).
> 
> Adds `lib/enrollment/from-groups.ts` to derive and merge `enrolledCourseSlugs` from group assignments, then applies it in admin user management (`createUser`, `updateUserGroups`, `updateUserCourses`) and in `getUserWithProfile` so the dashboard/authorization paths see the merged enrollment.
> 
> Expands cache invalidations after group/course updates to refresh `/dashboard` and relevant course routes (including `/simulador-aduanero`), and tightens typing in testimonial enrollment checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd759c7562675bb8fe592c4429413d3b0edbbdd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->