### PR TITLE
fix(aduanero): arreglo del formulaio de pedimento

### DIFF
--- a/app/simulador-aduanero/[caseKey]/resultado/page.tsx
+++ b/app/simulador-aduanero/[caseKey]/resultado/page.tsx
@@ -48,14 +48,25 @@ export default async function ResultadoPage({ params }: Props) {
 
   const progress = await assertStepAccessible(session.profile.id, caseKey, "resultado");
 
+  const alumnoNombre =
+    session.profile.name?.trim() || session.profile.email || "Alumno";
+
   const calibrated = progress.evaluatedAt != null;
   const bundle = loadCaseBundle(caseKey);
   const answersPlain = answersAsPlainObject(progress.answers);
 
   return (
     <div className="space-y-10">
-      <header className="space-y-3">
+      <header className="space-y-5">
         <h1 className="text-xl sm:text-3xl font-bold text-foreground">Resultado</h1>
+        <div className="max-w-xl rounded-xl border-2 border-primary/25 bg-primary/5 px-5 py-4 sm:px-6 sm:py-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Nombre del alumno
+          </p>
+          <p className="mt-1.5 text-2xl sm:text-3xl font-bold tracking-tight text-foreground leading-tight">
+            {alumnoNombre}
+          </p>
+        </div>
         <p className="max-w-xl text-sm sm:text-base text-muted-foreground">
           Calificación agregada del intento contra el caso (preguntas, pedimento y contribuciones).
           Tras confirmar podrás abrir{" "}

--- a/app/simulador-aduanero/[caseKey]/resumen/page.tsx
+++ b/app/simulador-aduanero/[caseKey]/resumen/page.tsx
@@ -51,14 +51,25 @@ export default async function ResumenPage({ params }: Props) {
 
   const progress = await assertStepAccessible(session.profile.id, caseKey, "resumen");
 
+  const alumnoNombre =
+    session.profile.name?.trim() || session.profile.email || "Alumno";
+
   const completed = parsedCompletedStages(progress);
   const resumenMarkedComplete = completed.includes("resumen");
   const answers = answersAsPlainObject(progress.answers);
 
   return (
     <div className="space-y-10">
-      <header className="space-y-3">
+      <header className="space-y-5">
         <h1 className="text-xl sm:text-3xl font-bold text-foreground">Resumen</h1>
+        <div className="max-w-xl rounded-xl border-2 border-primary/25 bg-primary/5 px-5 py-4 sm:px-6 sm:py-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Nombre del alumno
+          </p>
+          <p className="mt-1.5 text-2xl sm:text-3xl font-bold tracking-tight text-foreground leading-tight">
+            {alumnoNombre}
+          </p>
+        </div>
         <p className="max-w-xl text-sm sm:text-base text-muted-foreground">
           Recapitulación del caso <span className="font-medium">{bundle.case.title}</span>. El acceso
           exige haber ejecutado <span className="font-medium">Calificar</span> en Resultado (§6.10);

--- a/components/customs-simulator/simulator-form-fields.tsx
+++ b/components/customs-simulator/simulator-form-fields.tsx
@@ -99,11 +99,27 @@ export function SimulatorFormFieldsSection({
     });
   }
 
+  function buildAnswersSnapshot(): Record<string, string | number | boolean> {
+    const snapshot: Record<string, string | number | boolean> = {};
+    for (const f of fields) {
+      const raw = (values[f.id] ?? "").trim();
+      if (f.type === "number") {
+        const n = Number(String(values[f.id]).replace(",", "."));
+        snapshot[f.id] = Number.isFinite(n) ? n : raw;
+        continue;
+      }
+      snapshot[f.id] = raw;
+    }
+    return snapshot;
+  }
+
   function onFinalize() {
     startEnd(async () => {
+      const snapshot = buildAnswersSnapshot();
       const res = await markStageCompleteAction({
         caseKey,
         stepSlug: markCompleteSlug,
+        answersPatch: snapshot,
       });
       if (!res.ok) {
         toast.error(res.message);
@@ -135,7 +151,10 @@ export function SimulatorFormFieldsSection({
             </Label>
             {f.type === "select" && f.selectOptions?.length ? (
               <Select
-                value={values[f.id] ?? ""}
+                value={(() => {
+                  const v = (values[f.id] ?? "").trim();
+                  return v === "" ? undefined : v;
+                })()}
                 onValueChange={(v) => persistField(f.id, v)}
                 disabled={stageComplete}
               >

--- a/lib/actions/customsSimulatorProgress.ts
+++ b/lib/actions/customsSimulatorProgress.ts
@@ -26,10 +26,35 @@ const IMPLEMENTED_STEP_SLUGS = [
   "resumen",
 ] as const satisfies readonly MarkableSimulatorStepSlug[];
 
-const markStageCompleteSchema = z.object({
-  caseKey: z.string().trim().min(1).max(200),
-  stepSlug: z.enum(IMPLEMENTED_STEP_SLUGS),
-});
+const markStageCompleteSchema = z
+  .object({
+    caseKey: z.string().trim().min(1).max(200),
+    stepSlug: z.enum(IMPLEMENTED_STEP_SLUGS),
+    /** Unifica guardado + cierre en la misma acción para pedimento/contribuciones. */
+    answersPatch: z
+      .record(
+        z.string().max(200),
+        z.union([z.string(), z.number(), z.boolean()]),
+      )
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    const keys =
+      data.answersPatch !== undefined ? Object.keys(data.answersPatch) : [];
+    if (!data.answersPatch || keys.length === 0) return;
+    if (data.stepSlug !== "pedimento" && data.stepSlug !== "contribuciones") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "answersPatch sólo se usa al cerrar pedimento o contribuciones",
+      });
+    }
+    if (keys.length > 100) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "answersPatch debe tener máximo 100 claves",
+      });
+    }
+  });
 
 const stepSlugSchema = z.enum(
   SIMULATOR_STEP_SLUGS as unknown as readonly [
@@ -240,6 +265,26 @@ export async function markStageCompleteAction(
   }
 
   const { caseKey, stepSlug } = parsed.data;
+  try {
+    if (
+      parsed.data.answersPatch &&
+      Object.keys(parsed.data.answersPatch).length > 0 &&
+      (stepSlug === "pedimento" || stepSlug === "contribuciones")
+    ) {
+      await patchProgress(auth.profile.id, caseKey, {
+        answersPatch: parsed.data.answersPatch,
+        answerEditSourceStage: stepSlug as SimulatorStepSlug,
+      });
+    }
+  } catch (e) {
+    console.error("[markStageCompleteAction] pre-patch", e);
+    return {
+      ok: false,
+      code: "unexpected",
+      message: "No se pudo guardar las respuestas antes de cerrar la etapa",
+    };
+  }
+
   const outcome = await markStageComplete(auth.profile.id, caseKey, stepSlug);
 
   if (!outcome.ok) {

--- a/lib/customs-simulator/progress.ts
+++ b/lib/customs-simulator/progress.ts
@@ -85,6 +85,14 @@ async function getOrCreateProgressImpl(
 
 export const getOrCreateProgress = cache(getOrCreateProgressImpl);
 
+/** Lee/fila crea igual que `getOrCreateProgress`, pero sin memoización React. Tras `patchProgress` en la misma Server Action, `cache` devolvía la fila previa al merge y rompía la validación al cerrar pedimento/contribuciones. */
+export async function getSimulatorProgressFresh(
+  profileId: string,
+  caseKey: string,
+): Promise<CustomsProgressRow> {
+  return getOrCreateProgressImpl(profileId, caseKey);
+}
+
 export type ProgressPatchInput = {
   answersPatch?: Record<string, unknown>;
   /** Si se omite se conserva lo actual. Envío lista completa nueva (reemplazo). */

--- a/lib/customs-simulator/simulator-scoring.ts
+++ b/lib/customs-simulator/simulator-scoring.ts
@@ -12,7 +12,41 @@ function stringFromAnswer(raw: unknown): string {
   return typeof raw === "string" ? raw.trim() : String(raw ?? "").trim();
 }
 
-/** Valida captura pedimento/contribuciones servidor-side (sin exponer expected al cliente más allá de cerrar etapa). */
+function normalizeComparableString(value: string): string {
+  try {
+    return value.normalize("NFC").trim();
+  } catch {
+    return value.trim();
+  }
+}
+
+/**
+ * ¿El alumno dejó una captura no vacía y coherente con las opciones del caso?
+ * Cerrar pedimento/contribuciones no debe bloquearse por responder distinto del pedimento modelo:
+ * la corrección frente a `expected` sólo ocurre en `scoreSimulatorBundleAgainstAnswers` / Resultado.
+ */
+export function simulatorFormFieldCaptureComplete(
+  field: CaseBundle["pedimentoFields"][number] | CaseBundle["taxFields"][number],
+  raw: unknown,
+): boolean {
+  const v = answersValueForField(raw);
+  if (field.type === "select") {
+    if (v === undefined) return false;
+    const opts = field.selectOptions;
+    if (opts === undefined || opts.length === 0) return false;
+    const nv = normalizeComparableString(v);
+    return opts.some((o) => normalizeComparableString(o) === nv);
+  }
+  if (field.type === "text") {
+    return v !== undefined && v.trim() !== "";
+  }
+  if (field.type === "number") {
+    return numberFromAnswer(raw) !== null;
+  }
+  return false;
+}
+
+/** Comparación contra la respuesta correcta del caso (score y feedback en Resultado). */
 export function fieldMatchesExpected(
   field: CaseBundle["pedimentoFields"][number] | CaseBundle["taxFields"][number],
   raw: unknown,
@@ -20,13 +54,16 @@ export function fieldMatchesExpected(
   const v = answersValueForField(raw);
   if (v === undefined || v === "") return false;
   if (field.type === "select") {
-    return v === String(field.expected);
+    return normalizeComparableString(v) === normalizeComparableString(String(field.expected));
   }
   if (field.type === "text") {
+    const nv = normalizeComparableString(v);
     if (field.expectedContains) {
-      return v.toLowerCase().includes(field.expectedContains.toLowerCase());
+      return nv
+        .toLowerCase()
+        .includes(normalizeComparableString(field.expectedContains).toLowerCase());
     }
-    return v === String(field.expected);
+    return nv === normalizeComparableString(String(field.expected));
   }
   if (field.type === "number") {
     const n = numberFromAnswer(raw);

--- a/lib/customs-simulator/steps.ts
+++ b/lib/customs-simulator/steps.ts
@@ -12,13 +12,14 @@ import {
 } from "@/lib/data/customs-simulator/load";
 import type { JourneyEvent } from "@/lib/data/customs-simulator/schemas";
 import {
-  fieldMatchesExpected,
   scoreSimulatorBundleAgainstAnswers,
+  simulatorFormFieldCaptureComplete,
 } from "@/lib/customs-simulator/simulator-scoring";
 import {
   answersAsPlainObject,
   appendJourneyResolved,
   getOrCreateProgress,
+  getSimulatorProgressFresh,
   journeyResolvedAsArray,
   parsedCompletedStages,
   patchProgress,
@@ -186,7 +187,7 @@ export async function markStageComplete(
     }
 > {
   try {
-    const progress = await getOrCreateProgress(profileId, caseKey);
+    const progress = await getSimulatorProgressFresh(profileId, caseKey);
     const completed = parsedCompletedStages(progress);
     const expectedNext = SIMULATOR_STEP_SLUGS[completed.length];
     if (!expectedNext || expectedNext !== stepSlug) {
@@ -256,12 +257,11 @@ export async function markStageComplete(
 
     if (stepSlug === "pedimento") {
       for (const f of bundle.pedimentoFields) {
-        if (!fieldMatchesExpected(f, answers[f.id])) {
+        if (!simulatorFormFieldCaptureComplete(f, answers[f.id])) {
           return {
             ok: false,
             code: "pedimento_incomplete",
-            message:
-              "Revisa todos los campos del pedimento: valor inválido o incompleto.",
+            message: `Completa «${f.label}» con una opción o valor válido antes de cerrar.`,
           };
         }
       }
@@ -269,12 +269,11 @@ export async function markStageComplete(
 
     if (stepSlug === "contribuciones") {
       for (const f of bundle.taxFields) {
-        if (!fieldMatchesExpected(f, answers[f.id])) {
+        if (!simulatorFormFieldCaptureComplete(f, answers[f.id])) {
           return {
             ok: false,
             code: "contribuciones_incomplete",
-            message:
-              "Completa contribuciones con valores que cumplan los criterios del caso.",
+            message: `Completa «${f.label}» con una opción o valor válido antes de cerrar.`,
           };
         }
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Cambia la lógica de cierre/validación de etapas y el flujo de guardado en server actions, lo que puede afectar el avance del simulador si hay edge cases con `answersPatch` o cache/staleness. El impacto es acotado a `pedimento`/`contribuciones` y a comparaciones de strings en scoring/validación.
> 
> **Overview**
> Ajusta el flujo de *cierre de etapas* para `pedimento`/`contribuciones` unificando **guardar + cerrar**: el formulario ahora envía un snapshot (`answersPatch`) al `markStageCompleteAction`, que hace un pre-`patchProgress` antes de marcar la etapa completa.
> 
> Corrige validaciones que bloqueaban el cierre por no coincidir con el modelo: la completitud de `pedimento`/`contribuciones` pasa a validar captura válida (`simulatorFormFieldCaptureComplete`) en vez de `expected`, y se endurece la comparación de strings en scoring con normalización Unicode/trim.
> 
> Evita lecturas obsoletas al cerrar etapas introduciendo `getSimulatorProgressFresh` (sin `cache`) para la validación de `markStageComplete`. Además, `Resultado` y `Resumen` muestran el **nombre del alumno** en el header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb98c2c08f7d57a94d59b639f04429f6e8a3f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->